### PR TITLE
docs: add link to gatsby-plugin-umami

### DIFF
--- a/content/useful-links.md
+++ b/content/useful-links.md
@@ -13,6 +13,7 @@
 ## Integrations
 
 - [Umami Analytics Plugin for VuePress](https://github.com/spekulatius/vuepress-plugin-umami)
+- [Umami Analytics Plugin for Gatsby](https://github.com/phiilu/gatsby-plugin-umami)
 
 ## External articles
 

--- a/content/useful-links.md
+++ b/content/useful-links.md
@@ -13,7 +13,7 @@
 ## Integrations
 
 - [Umami Analytics Plugin for VuePress](https://github.com/spekulatius/vuepress-plugin-umami)
-- [Umami Analytics Plugin for Gatsby](https://github.com/phiilu/gatsby-plugin-umami)
+- [Umami Analytics Plugin for Gatsby](https://www.gatsbyjs.com/plugins/gatsby-plugin-umami/)
 
 ## External articles
 


### PR DESCRIPTION
Hey thanks for umami, love it so far! 

I created a plugin for [Gatsby](https://www.gatsbyjs.com/) and linked it in the documentation.