### PR TITLE
Using railway with forked repository

### DIFF
--- a/content/running-on-railway.md
+++ b/content/running-on-railway.md
@@ -29,3 +29,27 @@ You will be asked to add the `HASH_SALT` enviroment variable which is a random s
 - Make sure you [change your password](https://umami.is/docs/login) after you log in for the first time
 - Read more about [adding a website](https://umami.is/docs/add-a-website) and [collecting data](https://umami.is/docs/collect-data) here
 - [Here](https://umami-0ce3be-production.up.railway.app/share/QFjN7Inl/LTV) is a link to a shared dashboard hosted on Railway
+
+## Running on Railway from a forked repository
+
+The previously described method is the quickest and easiest way to get Umami up and running on Railway. However, this creates a new repository with a single commit under your Github account. You may want to use a forked repository instead to be able to conveniently receive updates from (or contribute pull requests to) the Umami source respository via github
+
+### Set up Railway project
+
+- Fork the [Umami repository](https://github.com/mikecao/umami).
+- Create an account on [Railway](https://railway.app/) connected to Github.
+- If you wish, you can give Railway permission only to your Umami fork repository when linking your Github account.
+- From the dashboard page click **New Project > Deploy from repo**.
+- Choose your forked Umami repository and select the **master** branch, click **Deploy**.
+
+This initial deploy will succeed, but attempting to open the app will show "Bad Gateway" until you follow the rest of these steps.
+
+### Database and Deploy
+
+- Click **Add Plugin** and select **Add PostgreSQL Plugin**
+- Click **Variables** and add `HASH_SALT`, set its value to a random string (this is a random string used to generate unique values for your installation). Click **Add**.
+- Add a second variable called `PORT`, set its value to a valid port number (eg: `3000`). Click **Add**.
+
+Adding the variables should trigger a re-deploy, and clicking the app link should get you to the login page of your Umami instance. 
+
+Follow the remaining instructions above from [Create database tables](#create-database-tables) to finish setting up your Umami instance on Railway.


### PR DESCRIPTION
Adding a short set of steps to describe getting off the ground using Umami + Railway without relying on the Railway starter button, which creates a disjointed personal repository. Also helps to address some possible bugs using a starter.