### PR TITLE
Update Railway deployment button

### DIFF
--- a/content/running-on-railway.md
+++ b/content/running-on-railway.md
@@ -8,7 +8,7 @@ Railway provides a free hosting services which allows you to deploy Umami and se
 
 ### Website and Database
 
-[![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/new?template=https%3A%2F%2Fgithub.com%2Frailwayapp%2Fexamples%2Ftree%2Fmaster%2Fexamples%2Fumami&plugins=postgresql&envs=HASH_SALT&HASH_SALTDesc=Any+random+string+used+to+generate+unique+values+for+your+installation)
+[![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/new/template?template=https%3A%2F%2Fgithub.com%2Frailwayapp-starters%2Fumami&plugins=postgresql&envs=HASH_SALT&HASH_SALTDesc=Any+random+string+used+to+generate+unique+values+for+your+installation)
 
 Click the button above to deploy your self-hosted version of the Umami website along with an automagically provisioned PostgreSQL database.
 


### PR DESCRIPTION
It looks like Railway moved the Umami starter to a separate repo so the deploy with Railway button didn't work. Closes mikecao/umami#712